### PR TITLE
Fix reference to potentially missing gems from gemspec

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 /.idea
 .DS_Store
 mollie-api-ruby*.gem
+Gemfile.lock
+.ruby-gemset

--- a/Gemfile
+++ b/Gemfile
@@ -1,0 +1,3 @@
+source "https://rubygems.org"
+
+gemspec

--- a/lib/Mollie/API/Client.rb
+++ b/lib/Mollie/API/Client.rb
@@ -2,6 +2,7 @@ require "json"
 require "rest_client"
 
 ["Exception",
+"Client/Version",
 "Resource/Base",
 "Resource/Payments",
 "Resource/Payments/Refunds",
@@ -17,7 +18,6 @@ require "rest_client"
 module Mollie
   module API
     class Client
-      CLIENT_VERSION = "1.1.4"
       API_ENDPOINT   = "https://api.mollie.nl"
       API_VERSION    = "v1"
 

--- a/lib/Mollie/API/Client/Version.rb
+++ b/lib/Mollie/API/Client/Version.rb
@@ -1,0 +1,7 @@
+module Mollie
+  module API
+    class Client
+      CLIENT_VERSION = "1.1.4"
+    end
+  end
+end

--- a/mollie.gemspec
+++ b/mollie.gemspec
@@ -1,6 +1,6 @@
 $:.unshift(File.join(File.dirname(__FILE__), 'lib'))
 
-require 'Mollie/API/Client'
+require 'Mollie/API/Client/Version'
 
 spec = Gem::Specification.new do |s|
   s.name = 'mollie-api-ruby'


### PR DESCRIPTION
mollie.gemspec `import`ed Mollie/API/Client, which then did `require
“rest_client”`. This is effectively a circular reference as it’s the
gemspec file that indicates this gem is required, and in a clean gemset
where rest-client is not installed the gem cannot be built.

This fix moves the version constant into a separate file with no
requirements of its own and references that from the gemspec,
preserving the existing API but removing the circular reference.

I’ve also added a Gemfile to make it easier to install the required
dependencies for working on the gem.